### PR TITLE
Add PHP 7.0/7.1 to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
+  - 7.1
 
 env:
   - DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test'

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,9 +41,9 @@ before_script:
   - cp phpunit.xml.dist phpunit.xml
 
 script:
-  - sh -c "if [ '$PHPCS' != '1' ]; then phpunit; fi"
+  - sh -c "if [ '$PHPCS' != '1' ]; then ./vendor/bin/phpunit; fi"
   - sh -c "if [ '$PHPCS' = '1' ]; then ./vendor/bin/phpcs -p --extensions=php --standard=psr2 --ignore=tests/bootstrap.php ./src ; fi"
-  - sh -c "if [ '$COVERALLS' = '1' ]; then phpunit --stderr --coverage-clover build/logs/clover.xml; fi"
+  - sh -c "if [ '$COVERALLS' = '1' ]; then ./vendor/bin/phpunit --stderr --coverage-clover build/logs/clover.xml; fi"
 
 after_script:
   - sh -c "if [ '$COVERALLS' = '1' ]; then php vendor/bin/coveralls -c .coveralls.yml -v; fi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
 before_script:
   - sh -c "if [ '$PHPCS' = '1' ]; then composer require squizlabs/php_codesniffer; fi"
 
-  - sh -c "if [ '$COVERALLS' = '1' ]; then composer require --dev satooshi/php-coveralls:dev-master; fi"
+  - sh -c "if [ '$COVERALLS' = '1' ]; then composer require --dev satooshi/php-coveralls:"^1.0"; fi"
   - sh -c "if [ '$COVERALLS' = '1' ]; then mkdir -p build/logs; fi"
 
   - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'CREATE DATABASE cakephp_test;'; fi"

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "sizuhiko/fabricate": "~2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "*"
+        "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
* `satooshi/php-coveralls` version was specified because PHP 5.4 failed coverage testing (see: https://travis-ci.org/tenkoma/cakephp-fabricate-adaptor/jobs/244258146 )
* Use `vendor/bin/phpunit` instead of Built-in `phpunit` (Because it build fails with PHP 5.6 https://travis-ci.org/tenkoma/cakephp-fabricate-adaptor/builds/244258135)